### PR TITLE
Setup

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@
 
 <img src="https://www.svgrepo.com/show/305241/github.svg"
     width="20" height="20"/>
-    [GitHub repository]( {{repo}})
+    [GitHub repository]( {{config.repo_url}})
 <img src="https://www.svgrepo.com/show/20800/event-date-and-time-symbol.svg"
     width="20" height="20"/>
     14 - 16 Juin, 2023

--- a/docs/pages/conda/conda-3-projects.md
+++ b/docs/pages/conda/conda-3-projects.md
@@ -10,20 +10,14 @@ environment for a project.
 
 Throughout these tutorials we will use a case study where we analyze an RNA-seq experiment with the multiresistant bacteria MRSA (see intro). You will now start to make a Conda yml file for this MRSA project. The file will contain a list of the software and versions needed to execute the analysis code.
 
-In this Conda tutorial, all code for the analysis is available in the script `~/training-reproducible-research-area/{{config.repo_name}}/code/run_qc.sh`. This code will download the raw FASTQ-files and subsequently run quality control on these using the FastQC software.
+In this Conda tutorial, all code for the analysis is available in the script `run_qc.sh`. This code will download the raw FASTQ-files and subsequently run quality control on these using the FastQC software.
 
 We will start by making a Conda yml-file that contains the required packages to perform these two steps. Later in the course, you will update the Conda yml-file with more packages, as the analysis workflow is expanded.
 
 * First be sure to be located in the tutorial dedicated folder:
 
 ```bash
-cd ~/training-reproducible-research-area/conda_tutorial
-```
-
-* Copy the `run_qc.sh` locally to make your life easier.
-
-```bash
-cp ~/training-reproducible-research-area/{{config.repo_name}}/code/run_qc.sh .
+cd {{training_path}}/conda_tutorial
 ```
 
 * Let's get going! Make a YAML file called `environment.yml` looking like

--- a/docs/pages/conda/conda-installation.md
+++ b/docs/pages/conda/conda-installation.md
@@ -1,12 +1,29 @@
-# Installing Conda
+{% raw %}
+# Setup Conda tutorial
 
+## Setup course material 
+
+??? quote "Follow the instructions below only if you start the course at this stage! Otherwise skip this step!"
+        This tutorial depends on files from the course GitHub repo. Please follow these instructions 
+        on how to set it up if you haven't done so already.  
+        Let's create a directory and clone the course GitHub repo.
+        ```bash
+        mkdir -p  {{training_path}}
+        cd {{training_path}}
+        git clone {{config.repo_url}}
+        ```
+
+## Setup environment 
 
 First let's create a dedicated folder for this tutorial:
 
 ```bash
-mkdir -p ~/training-reproducible-research-area/conda_tutorial
-cd ~/training-reproducible-research-area/conda_tutorial
+mkdir -p  {{training_path}}/conda_tutorial
+cd {{training_path}}/conda_tutorial
+cp -r {{training_path}}/{{config.repo_name}}/tutorials/conda/* . 
 ```
+
+## Installing Conda
 
 Conda is installed by downloading and executing an installer from the Conda
 website, but which version you need depends on your operating system. Choose the 
@@ -79,3 +96,5 @@ conda config --add channels bioconda
 conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
+
+{% endraw %}

--- a/docs/pages/containers/containers-1-introduction.md
+++ b/docs/pages/containers/containers-1-introduction.md
@@ -34,11 +34,6 @@ cluster environments, such as Uppmax. We will cover both Docker and Singularity
 in this course, but the focus will be be on the former (since that is the most
 widely used and runs on all three operating systems).
 
-This tutorial depends on files from the course GitHub repo. Take a look at the
-[setup](pre-course-setup) for instructions on how to install Docker if you
-haven't done so already, then open up a terminal and go to
-`workshop-reproducible-research/tutorials/containers`.
-
 !!! warning
     Docker images tend to take up quite a lot of space. In order to do all
     the exercises in this tutorial you need to have ~10 GB available.

--- a/docs/pages/containers/containers-installation.md
+++ b/docs/pages/containers/containers-installation.md
@@ -1,0 +1,31 @@
+{% raw %}
+# Setup Jupyter tutorial
+
+## Setup course material 
+
+??? info "Follow this instructions only if you start the course at this stage! Otherwise skip this step!"
+        This tutorial depends on files from the course GitHub repo. Please follow these instructions 
+        on how to set it up if you haven't done so already.  
+        Let's create a directory and clone the course GitHub repo.
+        
+        ```bash
+        mkdir -p  {{training_path}}
+        cd {{training_path}}
+        git clone {{config.repo_url}}
+        ```
+
+## Setup environment 
+
+First let's create a dedicated folder for this tutorial:
+
+```bash
+mkdir -p  {{training_path}}/containers
+cd {{training_path}}/containers
+cp -r {{training_path}}/{{config.repo_name}}/tutorials/containers/* . 
+```
+
+This tutorial depends on Docker and Singularity. Take a look at the
+[setup](../course-information/pre-course-setup.md) for instructions on how to install them if you
+haven't done so already.
+
+{% endraw %}

--- a/docs/pages/course-information/pre-course-setup.md
+++ b/docs/pages/course-information/pre-course-setup.md
@@ -1,3 +1,4 @@
+{% raw %}
 # Unix environment
 
 ## Setup for Mac / Linux users
@@ -6,11 +7,11 @@ You are lucky, using a UNIX based system as always been ideal for bioinformatics
 Open a bash shell terminal and follow the installation instructions.
 
 First, create and move into a directory on your computer where it makes
-sense to work during the course e.g. `~/training-reproducible-research-area`.
+sense to work during the course e.g. `{{training_path}}`.
 
 ```bash
-mkdir ~/training-reproducible-research-area
-cd ~/training-reproducible-research-area
+mkdir {{training_path}}
+cd {{training_path}}
 ```
 
 ## Setup for Windows users
@@ -43,7 +44,7 @@ resources:
 Open a bash shell Linux terminal and clone the GitHub repository containing all
 files you will need for completing the tutorials as follows. First, create and move into 
 a directory on your computer where it makes sense to work during
-the course e.g. `~/training-reproducible-research-area`.
+the course e.g. `{{training_path}}`.
 
 !!! tip
 
@@ -54,8 +55,8 @@ the course e.g. `~/training-reproducible-research-area`.
     Linux terminal by navigating to `/mnt/c/`.
 
 ```bash
-mkdir ~/training-reproducible-research-area
-cd ~/training-reproducible-research-area
+mkdir {{training_path}}
+cd {{training_path}}
 ```
 
 **Whenever a setup instruction specifies Mac or Linux (*i.e.* only those two,
@@ -203,3 +204,5 @@ Please follow the Windows-specific instructions at the [Singularity website](htt
     Version 6.1.28 of "Virtual box for Windows" may not work, please install
     Version 6.1.26 from [here](https://www.virtualbox.org/wiki/Download_Old_Builds_6_1)
     in case you encounter problems when trying to start the Vagrant VirtualBox.
+
+{% endraw %}

--- a/docs/pages/git/git-1-introduction.md
+++ b/docs/pages/git/git-1-introduction.md
@@ -43,7 +43,3 @@ These tutorials will walk you through the basics of using Git as a tool for
 reproducible research. The things covered in these tutorials are what you will
 be using most of the time in your day-to-day work with Git, but Git has many
 more advanced features that might be of use to you.
-
-This tutorial depends on files from the course GitHub repo. Take a look at the
-[setup](../course-information/pre-course-setup.md) for instructions on how to set it up if you haven't
-done so already.

--- a/docs/pages/git/git-2-creating-repositories.md
+++ b/docs/pages/git/git-2-creating-repositories.md
@@ -3,8 +3,8 @@
     To properly start this training session, you must be within a folder
     where it makes sense to work during the course:  
     ```
-    mkdir ~/training-reproducible-research-area
-    cd ~/training-reproducible-research-area
+    mkdir {{training_path}}
+    cd {{training_path}}
     ```
 
 Let's start by running this command:
@@ -68,7 +68,7 @@ cd ..
 ```
 
 !!! warning
-    From here you must be back to the `~/training-reproducible-research-area` directory  
+    From here you must be back to the `{{training_path}}` directory  
 
 In order to create a new Git repository, we first need a directory to track.
 Let's create one and move inside:

--- a/docs/pages/git/git-setup.md
+++ b/docs/pages/git/git-setup.md
@@ -1,3 +1,10 @@
+
+## Install git
+
+This tutorial depends on GIT. Take a look at the
+[setup](../course-information/pre-course-setup.md) for instructions on how to set it up if you haven't
+done so already.
+
 ## Configure git
 
 If it is the first time you use git on your computer, you may want to configure

--- a/docs/pages/jupyter/jupyter-installation.md
+++ b/docs/pages/jupyter/jupyter-installation.md
@@ -1,0 +1,34 @@
+{% raw %}
+# Setup Jupyter tutorial
+
+## Setup course material 
+
+??? info "Follow this instructions only if you start the course at this stage! Otherwise skip this step!"
+        This tutorial depends on files from the course GitHub repo. Please follow these instructions 
+        on how to set it up if you haven't done so already.  
+        Let's create a directory and clone the course GitHub repo.
+        
+        ```bash
+        mkdir -p  {{training_path}}
+        cd {{training_path}}
+        git clone {{config.repo_url}}
+        ```
+
+## Setup environment 
+
+First let's create a dedicated folder for this tutorial:
+
+```bash
+mkdir -p  {{training_path}}/jupyter
+cd {{training_path}}/jupyter
+cp -r {{training_path}}/{{config.repo_name}}/tutorials/jupyter/* . 
+```
+
+Let's continue using Conda for installing software, since it's so convenient to do so! Create a Conda environment from the environment.yml file and test the installation of Jupyter, like so:
+
+```bash
+conda env create -f environment.yml -n jupyter-env
+conda activate jupyter-env
+```
+
+{% endraw %}

--- a/docs/pages/nextflow/nextflow-installation.md
+++ b/docs/pages/nextflow/nextflow-installation.md
@@ -1,0 +1,26 @@
+{% raw %}
+# Setup Nextflow tutorial
+
+## Setup course material 
+
+??? info "Follow this instructions only if you start the course at this stage! Otherwise skip this step!"
+        This tutorial depends on files from the course GitHub repo. Please follow these instructions 
+        on how to set it up if you haven't done so already.  
+        Let's create a directory and clone the course GitHub repo.
+        
+        ```bash
+        mkdir -p  {{training_path}}
+        cd {{training_path}}
+        git clone {{config.repo_url}}
+        ```
+
+## Setup environment 
+
+First let's create a dedicated folder for this tutorial:
+
+```bash
+mkdir -p  {{training_path}}/nextflow
+cd {{training_path}}/nextflow
+```
+
+{% endraw %}

--- a/docs/pages/quarto/quarto-2-the-basics.md
+++ b/docs/pages/quarto/quarto-2-the-basics.md
@@ -18,7 +18,7 @@ And like with R markdown, you can click Render button to obtain your output !
 
 ![Demo](../images/quarto_demo.png)
 
-A small novelty: the appearance of the visaul button to have a more user friendly editor.
+A small novelty: the appearance of the visual button to have a more user friendly editor.
 
 ![code](../images/quarto_visual.png)
 
@@ -28,8 +28,7 @@ Want to know more ? You can go [here](https://quarto.org/docs/get-started/hello/
 
 One great thing about quarto is that you don't have to learn anything new! There is nothing new about Jupyter to know. Just how to convert it to HTML or whatever with Quarto. Let's play !
 
-Open up a terminal and go to
-`training-reproducible-research/tutorials/quarto` and run these commands to render Jupyter notebook with quarto: 
+Open up a terminal and run these commands to render Jupyter notebook with quarto: 
 
 ```bash "Terminal"
 quarto render supplementary_material.ipynb --to html

--- a/docs/pages/quarto/quarto-installation.md
+++ b/docs/pages/quarto/quarto-installation.md
@@ -1,0 +1,37 @@
+{% raw %}
+# Setup Quarto tutorial
+
+## Setup course material 
+
+??? info "Follow this instructions only if you start the course at this stage! Otherwise skip this step!"
+        This tutorial depends on files from the course GitHub repo. Please follow these instructions 
+        on how to set it up if you haven't done so already.  
+        Let's create a directory and clone the course GitHub repo.
+        
+        ```bash
+        mkdir -p  {{training_path}}
+        cd {{training_path}}
+        git clone {{config.repo_url}}
+        ```
+
+## Setup environment 
+
+First let's create a dedicated folder for this tutorial:
+
+```bash
+mkdir -p  {{training_path}}/quarto
+cd {{training_path}}/quarto
+cp -r {{training_path}}/{{config.repo_name}}/tutorials/quarto/* . 
+```
+
+??? quote "Follow the instructions below only if you start the course at this stage! Otherwise skip this step!"
+        ```bash
+        conda env create -f {{training_path}}/{{config.repo_name}}/tutorials/rmarkdown/environment.yml -n rmarkdown-env
+        ```
+
+Now activate the environment containing RStudio:
+```
+conda activate rmarkdown-env
+```
+
+{% endraw %}

--- a/docs/pages/rmarkdown/r-markdown-installation.md
+++ b/docs/pages/rmarkdown/r-markdown-installation.md
@@ -1,0 +1,50 @@
+{% raw %}
+# Setup R-markdown tutorial
+
+## Setup course material 
+
+??? info "Follow this instructions only if you start the course at this stage! Otherwise skip this step!"
+        This tutorial depends on files from the course GitHub repo. Please follow these instructions 
+        on how to set it up if you haven't done so already.  
+        Let's create a directory and clone the course GitHub repo.
+        
+        ```bash
+        mkdir -p  {{training_path}}
+        cd {{training_path}}
+        git clone {{config.repo_url}}
+        ```
+
+## Setup environment 
+
+First let's create a dedicated folder for this tutorial:
+
+```bash
+mkdir -p  {{training_path}}/rmarkdown
+cd {{training_path}}/rmarkdown
+cp -r {{training_path}}/{{config.repo_name}}/tutorials/rmarkdown/* . 
+```
+
+We will use Conda environments for the set up of this tutorial. So, now we will install all the tools via conda:
+
+```bash
+conda env create -f {{training_path}}/{{config.repo_name}}/tutorials/rmarkdown/environment.yml -n rmarkdown-env
+conda activate rmarkdown-env
+```
+
+You can then activate the environment followed by running RStudio in the background from the command line:
+
+conda activate rmarkdown-env
+rstudio &
+
+!!! tip "The sluggishness of Conda"
+        Some environments are inherently quite complicated in that they have many and varied dependencies, meaning that the search space for the entire dependency hierarchy becomes huge - leading to slow and sluggish installations. This is often the case for R environments. This can be improved by using Mamba, a faster wrapper around Conda. Simply run conda install -n base mamba to install Mamba in your base environment, and replace any conda command with mamba - except activating and deactivating environments, which still needs to be done using Conda.
+
+!!! tip "RStudio and Conda"
+        In some cases RStudio doesn't play well with Conda due to differing libpaths. The first and simplest thing to try is to always start RStudio from the command line (rstudio &). If you're still having issues, check the available library path by .libPaths() to make sure that it points to a path within your Conda environment. It might be that .libPaths() shows multiple library paths, in which case R packages will be searched for by R in all these locations. This means that your R session will not be completely isolated in your Conda environment and that something that works for you might not work for someone else using the same Conda environment, simply because you had additional packages installed in the second library location. One way to force R to just use the conda library path is to add a .Renviron file to the directory where you start R with these lines:
+        ```
+        R_LIBS_USER=""
+        R_LIBS=""
+        ```
+        ... and restart RStudio. The rmarkdown/ directory in the course materials already contains this file, so you shouldn't have to add this yourself, but we mention it here for your future projects.
+
+{% endraw %}

--- a/docs/pages/snakemake/snakemake-1-introduction.md
+++ b/docs/pages/snakemake/snakemake-1-introduction.md
@@ -30,9 +30,3 @@ By keeping track of when each file was generated, and by which operation, it is
 possible to ensure that there is a consistent "paper trail" from raw data to
 final results. Snakemake also has features that allow you to package and
 distribute the workflow, and any files it involves, once it's done.
-
-This tutorial depends on files from the course GitHub repo. Take a look at the
-[setup](pre-course-setup) for instructions on how to set it up if you haven't
-done so already, then open up a terminal and go to
-`workshop-reproducible-research/tutorials/snakemake` and activate your
-`snakemake-env` Conda environment.

--- a/docs/pages/snakemake/snakemake-4-the-mrsa-workflow.md
+++ b/docs/pages/snakemake/snakemake-4-the-mrsa-workflow.md
@@ -1,3 +1,4 @@
+{% raw %}
 As you might remember from the [intro](introduction), we are attempting to
 understand how lytic bacteriophages can be used as a future therapy for the
 multiresistant bacteria MRSA (methicillin-resistant _Staphylococcus aureus_).
@@ -9,7 +10,7 @@ workflow to make it more flexible and reproducible!
 !!! Tip
     This section will leave a little more up to you compared to the previous
     one. If you get stuck at some point the final workflow after all the
-    modifications is available in `tutorials/git/Snakefile`.
+    modifications is available in `{{training_path}}/{{config.repo_name}}/tutorials/git/Snakefile`.
 
 You are probably already in your `snakemake-env` environment, otherwise
 activate it (use `conda info --envs` if you are unsure).
@@ -121,3 +122,5 @@ and the count table in `results/tables`.
     - How the MRSA workflow looks.
     - How to run the MRSA workflow.
     - Which output files the MRSA workflow produces.
+
+{% endraw %}

--- a/docs/pages/snakemake/snakemake-installation.md
+++ b/docs/pages/snakemake/snakemake-installation.md
@@ -1,0 +1,36 @@
+{% raw %}
+# Setup Snakemake tutorial
+
+## Setup course material 
+
+??? info "Follow this instructions only if you start the course at this stage! Otherwise skip this step!"
+        This tutorial depends on files from the course GitHub repo. Please follow these instructions 
+        on how to set it up if you haven't done so already.  
+        Let's create a directory and clone the course GitHub repo.
+        
+        ```bash
+        mkdir -p  {{training_path}}
+        cd {{training_path}}
+        git clone {{config.repo_url}}
+        ```
+
+## Setup environment 
+
+First let's create a dedicated folder for this tutorial:
+
+```bash
+mkdir -p  {{training_path}}/snakemake
+cd {{training_path}}/snakemake
+cp -r {{training_path}}/{{config.repo_name}}/tutorials/snakemake/* . 
+```
+
+We will use Conda environments for the set up of this tutorial. So, now we will install all the tools via conda:
+
+```bash
+conda env create -f environment.yml -n snakemake-env
+conda activate snakemake-env
+```
+
+
+
+{% endraw %}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -88,6 +88,7 @@ extra:
   contact: https://www.southgreen.fr/contact
   institute: SouthGreen
   color_table_header: "#333a99"
+  training_path: "~/training-reproducible-research-area"
 
 # page tree
 nav:
@@ -110,13 +111,14 @@ nav:
           - Extra material: pages/git/git-9-extra-material.md
         - Conda:
           - Introduction: pages/conda/conda-1-introduction.md
-          - Installation: pages/conda/conda-installation.md
+          - Setup: pages/conda/conda-installation.md
           - The basics: pages/conda/conda-2-the-basics.md
           - Projects: pages/conda/conda-3-projects.md
           - Extra material: pages/conda/conda-4-extra-material.md
         - Workflow Manager System:
           - Snakemake:
             - Introduction: pages/snakemake/snakemake-1-introduction.md
+            - Setup: pages/snakemake/snakemake-installation.md
             - The basics: pages/snakemake/snakemake-2-the-basics.md
             - Visualising workflow: pages/snakemake/snakemake-3-visualising-workflows.md
             - The MRSA Workflow: pages/snakemake/snakemake-4-the-mrsa-workflow.md
@@ -129,6 +131,7 @@ nav:
             - Extra material: pages/snakemake/snakemake-11-extra-material.md
           - Nextflow:
             - Introduction: pages/nextflow/nextflow-1-introduction.md
+            - Setup: pages/nextflow/nextflow-installation.md
             - Getting started with nf-core: pages/nextflow/nextflow-nfcore.md
             - The basics: pages/nextflow/nextflow-2-the-basics.md
             - Executing workflows: pages/nextflow/nextflow-3-executing-workflows.md
@@ -136,9 +139,9 @@ nav:
             - Workflow configuration: pages/nextflow/nextflow-5-workflow-configuration.md
             - Optmising the MRSA workflow: pages/nextflow/nextflow-6-optimising-the-mrsa-workflow.md
             - Extra material: pages/nextflow/nextflow-7-extra-material.md
-
         - Containers:
           - Introduction: pages/containers/containers-1-introduction.md
+          - Setup: pages/containers/containers-installation.md
           - The basics: pages/containers/containers-2-the-basics.md
           - Building a Docker image: pages/containers/containers-3-building-images.md
           - Managing containers: pages/containers/containers-4-managing-containers.md
@@ -148,6 +151,7 @@ nav:
           - Extra material: pages/containers/containers-8-extra-material.md
         - R Markdown:
           - Introduction: pages/rmarkdown/r-markdown-1-introduction.md
+          - Setup: pages/rmarkdown/r-markdown-installation.md
           - The basics: pages/rmarkdown/r-markdown-2-the-basics.md
           - Text: pages/rmarkdown/r-markdown-3-text.md
           - Code chunks: pages/rmarkdown/r-markdown-4-code-chunks.md
@@ -157,6 +161,7 @@ nav:
           - Extra materiel: pages/rmarkdown/r-markdown-8-extra-material.md
         - Jupyter:
           - Introduction: pages/jupyter/jupyter-1-introduction.md
+          - Setup: pages/jupyter/jupyter-installation.md
           - The basics: pages/jupyter/jupyter-2-the-basics.md
           - Magics: pages/jupyter/jupyter-3-magics.md
           - Plotting: pages/jupyter/jupyter-4-plotting.md
@@ -167,6 +172,7 @@ nav:
           - Extra material: pages/jupyter/jupyter-9-extra-material.md
         - Quarto:
           - Introduction: pages/quarto/quarto-1-introduction.md
+          - Setup: pages/quarto/quarto-installation.md
           - The basics: pages/quarto/quarto-2-the-basics.md
           - Rendering: pages/quarto/quarto-3-the-rendering.md
           - Extensions: pages/quarto/quarto-4-the-extensions.md


### PR DESCRIPTION
Fix #17
Add setup at each section.
Now we do not work anymore I the folder and the cloned repo but instead create a dedicated folder where we copy everything we need from the repo.
Now it is possible to start any tutorial without having followed a previous one.

I use the variable {{training_path}} (ninja style) for the path that is common to all tutorial.
!! you need to use {% raw %} {% endraw %} attribute to embed the page when using this ninja style variable {{ }}